### PR TITLE
Feat: 회원가입 API 구현 및 가입시 자동로그인 연동

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handlers as GET, handlers as POST } from "@/lib/auth"; // 임시 (테스트용)

--- a/app/api/auth/sign-up/route.ts
+++ b/app/api/auth/sign-up/route.ts
@@ -3,6 +3,7 @@ import { signUpSchema } from "@/lib/validators/auth";
 import prisma from "@/lib/prisma";
 import bcrypt from "bcrypt";
 import { SIGNUP_STATUS } from "config/constants";
+import { signIn } from "@/lib/auth";
 
 export const POST = async (req: NextRequest) => {
   try {
@@ -11,7 +12,12 @@ export const POST = async (req: NextRequest) => {
 
     if (!validatedData.success) {
       return NextResponse.json(
-        { message: SIGNUP_STATUS.ERROR.INVALID_INPUT },
+        {
+          error: {
+            code: "INVALID_INPUT",
+            message: SIGNUP_STATUS.ERROR.INVALID_INPUT,
+          },
+        },
         { status: 400 }
       );
     }
@@ -21,12 +27,17 @@ export const POST = async (req: NextRequest) => {
 
     if (exist) {
       return NextResponse.json(
-        { message: SIGNUP_STATUS.ERROR.EMAIL_ALREADY_EXISTS },
+        {
+          error: {
+            code: "EMAIL_ALREADY_EXISTS",
+            message: SIGNUP_STATUS.ERROR.EMAIL_ALREADY_EXISTS,
+          },
+        },
         { status: 409 }
       );
     }
-    const saltRound = 12;
-    const hashedPassword = await bcrypt.hash(password, saltRound);
+    const SALT_ROUNDS = 12;
+    const hashedPassword = await bcrypt.hash(password, SALT_ROUNDS);
 
     const user = await prisma.user.create({
       data: {
@@ -37,13 +48,29 @@ export const POST = async (req: NextRequest) => {
       select: { id: true, email: true, phoneNumber: true, createdAt: true },
     });
 
+    const signInResult = await signIn("credentials", {
+      email: user.email,
+      password,
+      redirect: true,
+      redirectTo: `/dashboard/${user.id}/chatbot/setting`,
+    });
+
+    if (signInResult) {
+      return signInResult;
+    }
+
     return NextResponse.json(
       { data: user, message: SIGNUP_STATUS.SUCCESS.CREATE },
       { status: 201 }
     );
   } catch (err) {
     return NextResponse.json(
-      { message: SIGNUP_STATUS.ERROR.SIGNUP_SERVER_ERROR },
+      {
+        error: {
+          code: "SIGNUP_SERVER_ERROR",
+          message: SIGNUP_STATUS.ERROR.SIGNUP_SERVER_ERROR,
+        },
+      },
       { status: 500 }
     );
   }

--- a/app/api/auth/sign-up/route.ts
+++ b/app/api/auth/sign-up/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { signUpSchema } from "@/lib/validators/auth";
+import prisma from "@/lib/prisma";
+import bcrypt from "bcrypt";
+import { SIGNUP_STATUS } from "config/constants";
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const json = await req.json();
+    const validatedData = signUpSchema.safeParse(json);
+
+    if (!validatedData.success) {
+      return NextResponse.json(
+        { message: SIGNUP_STATUS.ERROR.INVALID_INPUT },
+        { status: 400 }
+      );
+    }
+
+    const { email, password, phoneNumber } = validatedData.data;
+    const exist = await prisma.user.findUnique({ where: { email } });
+
+    if (exist) {
+      return NextResponse.json(
+        { message: SIGNUP_STATUS.ERROR.EMAIL_ALREADY_EXISTS },
+        { status: 409 }
+      );
+    }
+    const saltRound = 12;
+    const hashedPassword = await bcrypt.hash(password, saltRound);
+
+    const user = await prisma.user.create({
+      data: {
+        email,
+        passwordHash: hashedPassword,
+        phoneNumber,
+      },
+      select: { id: true, email: true, phoneNumber: true, createdAt: true },
+    });
+
+    return NextResponse.json(
+      { data: user, message: SIGNUP_STATUS.SUCCESS.CREATE },
+      { status: 201 }
+    );
+  } catch (err) {
+    return NextResponse.json(
+      { message: SIGNUP_STATUS.ERROR.SIGNUP_SERVER_ERROR },
+      { status: 500 }
+    );
+  }
+};

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,0 +1,26 @@
+/** 회원가입 상태 */
+export const SIGNUP_STATUS = {
+  SUCCESS: {
+    CREATE: "회원가입이 완료 되었습니다.",
+  },
+  ERROR: {
+    INVALID_INPUT: "입력값 오류입니다.",
+    EMAIL_ALREADY_EXISTS: "이미 사용 중인 이메일입니다.",
+    SIGNUP_SERVER_ERROR: "회원가입을 다시 해주세요.",
+  },
+};
+
+/** Auth zod 유효성 검사  */
+export const AUTH_VALIDATION = {
+  MESSAGES: {
+    EMAIL_INVALID: "올바른 이메일 형식이 아닙니다.",
+    PHONE_INVALID: "올바른 전화번호 형식이 아닙니다",
+    PASSWORD_TOO_SHORT: "비밀번호는 최소 8자 이상이어야 합니다.",
+    PASSWORD_TOO_LONG: "비밀번호는 72자 이하여야 합니다.",
+    PHONE_TOO_SHORT: "전화번호가 너무 짧습니다.",
+    PHONE_TOO_LONG: "전화번호가 너무 깁니다.",
+  },
+  PHONE_NUMBER: {
+    PATTERN: /^010-\d{4}-\d{4}$/,
+  },
+};

--- a/config/constants.js
+++ b/config/constants.js
@@ -21,6 +21,6 @@ export const AUTH_VALIDATION = {
     PHONE_TOO_LONG: "전화번호가 너무 깁니다.",
   },
   PHONE_NUMBER: {
-    PATTERN: /^010-\d{4}-\d{4}$/,
+    PATTERN: /^\+82\d{8,10}$/,
   },
 };

--- a/lib/auth-edge.ts
+++ b/lib/auth-edge.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+
+export const { auth } = NextAuth({
+  session: { strategy: "jwt" },
+  providers: [],
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,48 @@
 import NextAuth from "next-auth";
 import prisma from "./prisma";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcrypt";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
-  providers: [],
+  session: { strategy: "jwt" },
+  providers: [
+    Credentials({
+      async authorize(credentials: { email?: string; password?: string }) {
+        if (!credentials) {
+          return null;
+        }
+
+        const email = credentials.email;
+        const password = credentials.password;
+
+        if (!email || !password) {
+          return null;
+        }
+
+        const user = await prisma.user.findUnique({
+          where: { email: email },
+        });
+
+        if (!user || !user.passwordHash) {
+          return null;
+        }
+
+        const isPasswordValid = await bcrypt.compare(
+          password,
+          user.passwordHash
+        );
+
+        if (!isPasswordValid) {
+          return null;
+        }
+
+        return {
+          id: user.id,
+          email: user.email,
+        };
+      },
+    }),
+  ],
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,8 @@
+import NextAuth from "next-auth";
+import prisma from "./prisma";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  providers: [],
+});

--- a/lib/validators/auth.ts
+++ b/lib/validators/auth.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { AUTH_VALIDATION } from "config/constants";
+export const signUpSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email({ message: AUTH_VALIDATION.MESSAGES.EMAIL_INVALID }),
+  password: z
+    .string()
+    .trim()
+    .min(8, { message: AUTH_VALIDATION.MESSAGES.PASSWORD_TOO_SHORT })
+    .max(72, { message: AUTH_VALIDATION.MESSAGES.PASSWORD_TOO_LONG }),
+  phoneNumber: z
+    .string()
+    .regex(AUTH_VALIDATION.PHONE_NUMBER.PATTERN, {
+      message: AUTH_VALIDATION.MESSAGES.PHONE_INVALID,
+    })
+    .trim()
+    .min(7, { message: AUTH_VALIDATION.MESSAGES.PHONE_TOO_SHORT })
+    .max(32, { message: AUTH_VALIDATION.MESSAGES.PHONE_TOO_LONG }),
+});
+
+export type SignUpSchema = z.infer<typeof signUpSchema>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,1 @@
+export { auth as middleware } from "@/lib/auth";

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,1 +1,1 @@
-export { auth as middleware } from "@/lib/auth";
+export { auth as middleware } from "@/lib/auth-edge";

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "zod": "^3.25.17"
   },
   "devDependencies": {
+    "@auth/prisma-adapter": "^2.10.0",
     "@types/bcrypt": "^5.0.2",
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bcrypt": "^5.1.1",
     "clsx": "^2.1.1",
     "next": "latest",
-    "next-auth": "5.0.0-beta.25",
+    "next-auth": "5.0.0-beta.29",
     "postcss": "8.5.1",
     "postgres": "^3.4.6",
     "react": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
         specifier: ^3.25.17
         version: 3.25.17
     devDependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.10.0
+        version: 2.10.0(@prisma/client@6.15.0(prisma@6.15.0(typescript@5.7.3))(typescript@5.7.3))
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
@@ -122,6 +125,11 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  '@auth/prisma-adapter@2.10.0':
+    resolution: {integrity: sha512-EliOQoTjGK87jWWqnJvlQjbR4PjQZQqtwRwPAe108WwT9ubuuJJIrL68aNnQr4hFESz6P7SEX2bZy+y2yL37Gw==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -2527,6 +2535,15 @@ snapshots:
       oauth4webapi: 3.5.1
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/prisma-adapter@2.10.0(@prisma/client@6.15.0(prisma@6.15.0(typescript@5.7.3))(typescript@5.7.3))':
+    dependencies:
+      '@auth/core': 0.40.0
+      '@prisma/client': 6.15.0(prisma@6.15.0(typescript@5.7.3))(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@emnapi/core@1.4.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: latest
         version: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
-        specifier: 5.0.0-beta.25
-        version: 5.0.0-beta.25(next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        specifier: 5.0.0-beta.29
+        version: 5.0.0-beta.29(next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       postcss:
         specifier: 8.5.1
         version: 8.5.1
@@ -109,8 +109,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@auth/core@0.37.2':
-    resolution: {integrity: sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==}
+  '@auth/core@0.40.0':
+    resolution: {integrity: sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
@@ -639,9 +639,6 @@ packages:
   '@types/bcrypt@5.0.2':
     resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1056,10 +1053,6 @@ packages:
 
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
-
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
-    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1698,8 +1691,8 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+  jose@6.1.0:
+    resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1830,8 +1823,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next-auth@5.0.0-beta.25:
-    resolution: {integrity: sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==}
+  next-auth@5.0.0-beta.29:
+    resolution: {integrity: sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
@@ -2075,13 +2068,13 @@ packages:
     resolution: {integrity: sha512-MXrZVqgUfiirfZ0MqQqXqZQa6oM5OWFjfuaHVKl7v2zW25LnOJeLpQk+UUW0ZuP94fcS+fZVqyDYm9v5SIJ11Q==}
     engines: {node: '>=12'}
 
-  preact-render-to-string@5.2.3:
-    resolution: {integrity: sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==}
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
     peerDependencies:
       preact: '>=10'
 
-  preact@10.11.3:
-    resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2095,9 +2088,6 @@ packages:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
-
-  pretty-format@3.8.0:
-    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   prisma@6.15.0:
     resolution: {integrity: sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==}
@@ -2530,15 +2520,13 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@auth/core@0.37.2':
+  '@auth/core@0.40.0':
     dependencies:
       '@panva/hkdf': 1.2.1
-      '@types/cookie': 0.6.0
-      cookie: 0.7.1
-      jose: 5.10.0
+      jose: 6.1.0
       oauth4webapi: 3.5.1
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3(preact@10.11.3)
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -2939,8 +2927,6 @@ snapshots:
   '@types/bcrypt@5.0.2':
     dependencies:
       '@types/node': 22.10.7
-
-  '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3386,8 +3372,6 @@ snapshots:
   consola@3.4.2: {}
 
   console-control-strings@1.1.0: {}
-
-  cookie@0.7.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4203,7 +4187,7 @@ snapshots:
 
   jiti@2.5.1: {}
 
-  jose@5.10.0: {}
+  jose@6.1.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4313,9 +4297,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@5.0.0-beta.25(next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+  next-auth@5.0.0-beta.29(next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@auth/core': 0.37.2
+      '@auth/core': 0.40.0
       next: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
@@ -4538,12 +4522,11 @@ snapshots:
 
   postgres@3.4.6: {}
 
-  preact-render-to-string@5.2.3(preact@10.11.3):
+  preact-render-to-string@6.5.11(preact@10.24.3):
     dependencies:
-      preact: 10.11.3
-      pretty-format: 3.8.0
+      preact: 10.24.3
 
-  preact@10.11.3: {}
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -4552,8 +4535,6 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@3.6.2: {}
-
-  pretty-format@3.8.0: {}
 
   prisma@6.15.0(typescript@5.7.3):
     dependencies:


### PR DESCRIPTION
## 구현된 기능
- 회원 가입 api를 통해 사용자가 회원가입을 할 수 있습니다.
- 사용자의 입력 정보를 가지고 가입된 회원인지 아닌지 판단합니다.
- 가입된 회원이거나 가입되지 않은 신규 회원일때 혹은 각 에러에 대한 각각의 응답을 받습니다.
- 신규회원일때 가입시 자동으로 로그인 되며 챗봇 settimg 경로로 이동하게 됩니다. 

## 상세 설명

- 회원가입 API 구현 (POST /api/sign-up) 
  - signUpSchema로 입력값을 검증합니다. (이메일/비밀번호/전화번호)
  - 비밀번호는 bcrypt로 SALT_ROUNDS=12 해시 후 저장합니다.
  - 성공 시 생성 사용자(id, email, phoneNumber, createdAt)를 선택 조회합니다.

- 가입시 자동로그인  (api/sign-up)
  - signIn("credentials")를 호출하여 즉시 인증합니다.
  - 가입 후 경로 는 /dashboard/{user.id}/chatbot/setting입니다.

- 자동 로그인시 검증 (lib/auth.ts)
  - authorize에서 이메일로 사용자 조회 후 bcrypt.compare로 비밀번호를 검증합니다.
  -  jwt를 유지합니다.

- 상수 및 유효성 검사
  - 메세지 및 관련 로직은 상수 처리 하였습니다.
  - 전화번호는 형식 ^\+82\d{8,10}$을 적용하였습니다.


## 참고사항

- 흐름 요약: 회원가입 → 비밀번호 해시 저장 → 즉시 Credentials 로그인 → 대시보드의 AI 설정으로 이동합니다
- 로그인 & 로그아웃 API 작업이 안되어 임시 파일들이 존재합니다. 추후 수정 및 작성 예정입니다.

## PR 체크 사항

- [ ] 회원가입 API가 입력값(email, password, phoneNumber)을 Zod 스키마에 따라 정상적으로 검증하는가
- [ ] 비밀번호가 bcrypt(SALT_ROUNDS=12)로 안전하게 해시되는가
- [ ] 회원가입 직후 signIn("credentials")가 실행되어 세션 쿠키 발급 및 인증 상태 유지가 가능한가
- [ ] Auth.js Credentials Provider의 authorize 함수가 이메일 조회와 bcrypt 비밀번호 검증을 올바르게 처리되었나

## 리뷰 반영사항

-