### PR TITLE
Feat: crawler 후 텍스트 임베딩하여 Pinecone 인덱스 저장

### DIFF
--- a/app/api/crawl/crawler.ts
+++ b/app/api/crawl/crawler.ts
@@ -1,0 +1,70 @@
+import * as cheerio from "cheerio";
+import { NodeHtmlMarkdown } from "node-html-markdown";
+import prisma from "@/lib/prisma";
+
+export type Page = {
+  url: string;
+  content: string;
+};
+
+export const crawler = () => {
+  const visitedUrls = new Set<string>();
+  const crawledPages: Page[] = [];
+  const pendingQueue: { url: string; depth: number }[] = [];
+
+  const maxDepth = 2;
+  const maxPages = 1;
+
+  const crawlByBotId = async (botId: string): Promise<Page[]> => {
+    const chatBot = await prisma.chatbot.findUnique({
+      where: { id: botId },
+    });
+
+    if (!chatBot) {
+      throw new Error("챗봇을 찾을 수 없습니다.");
+    }
+
+    return crawl(chatBot.companyUrl);
+  };
+
+  const crawl = async (startUrl: string): Promise<Page[]> => {
+    pendingQueue.push({ url: startUrl, depth: 0 });
+
+    while (pendingQueue.length > 0 && crawledPages.length < maxPages) {
+      const task = pendingQueue.shift();
+
+      if (!task) break;
+
+      const url = task.url;
+      const depth = task.depth;
+
+      if (depth > maxDepth || visitedUrls.has(url)) continue;
+      visitedUrls.add(url);
+
+      const response = await fetch(url);
+      const html = await response.text();
+
+      const $ = cheerio.load(html);
+      $("a").removeAttr("href");
+      const markdown = NodeHtmlMarkdown.translate($.html());
+
+      crawledPages.push({ url, content: markdown });
+
+      const relativeHrefs = $("a")
+        .map((_, link) => $(link).attr("href"))
+        .get()
+        .filter(
+          (href): href is string => typeof href === "string" && href.length > 0
+        );
+
+      const absoluteUrls = relativeHrefs.map((rel) => new URL(rel, url).href);
+      for (const nextUrl of absoluteUrls) {
+        pendingQueue.push({ url: nextUrl, depth: depth + 1 });
+      }
+    }
+
+    return crawledPages;
+  };
+
+  return { crawl, crawlByBotId };
+};

--- a/app/api/crawl/crawler.ts
+++ b/app/api/crawl/crawler.ts
@@ -66,5 +66,5 @@ export const crawler = () => {
     return crawledPages;
   };
 
-  return { crawl, crawlByBotId };
+  return { crawler, crawlByBotId };
 };

--- a/app/api/crawl/crawler.ts
+++ b/app/api/crawl/crawler.ts
@@ -66,5 +66,5 @@ export const crawler = () => {
     return crawledPages;
   };
 
-  return { crawler, crawlByBotId };
+  return { crawl, crawlByBotId };
 };

--- a/app/api/crawl/seed.ts
+++ b/app/api/crawl/seed.ts
@@ -1,0 +1,135 @@
+import { crawler } from "./crawler";
+import {
+  Pinecone,
+  PineconeRecord,
+  Index,
+  ServerlessSpecCloudEnum,
+} from "@pinecone-database/pinecone";
+import type { Page } from "./crawler";
+import {
+  RecursiveCharacterTextSplitter,
+  MarkdownTextSplitter,
+} from "@langchain/textsplitters";
+import { Document } from "@langchain/core/documents";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+interface SeedOptions {
+  splittingMethod: string;
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
+export type Seed = {
+  url: string;
+  limit: number;
+  indexName: string;
+  options: SeedOptions;
+  cloudName: ServerlessSpecCloudEnum;
+  regionName: string;
+};
+
+type DocumentSplitter = RecursiveCharacterTextSplitter | MarkdownTextSplitter;
+
+export const seed = async ({
+  url,
+  limit,
+  indexName,
+  options,
+  cloudName,
+  regionName,
+}: Seed) => {
+  try {
+    const pinecone = new Pinecone({
+      apiKey: process.env.PINECONE_API_KEY!,
+    });
+
+    const { splittingMethod, chunkSize, chunkOverlap } = options;
+    const { crawl } = crawler();
+    const crawledPages = await crawl(url);
+    const limitSafe = Math.max(0, limit ?? 100);
+    const limitedPages = crawledPages.slice(0, limitSafe);
+
+    const textSplitter: DocumentSplitter =
+      splittingMethod === "recursive"
+        ? new RecursiveCharacterTextSplitter({ chunkSize, chunkOverlap })
+        : new MarkdownTextSplitter();
+
+    const splitDocuments = await Promise.all(
+      limitedPages.map((page) => splitPageToDocument(page, textSplitter))
+    );
+
+    const indexList = await pinecone.listIndexes();
+    const indexExists =
+      indexList.indexes?.some((index) => index.name === indexName) ?? false;
+
+    if (!indexExists) {
+      await pinecone.createIndex({
+        name: indexName,
+        dimension: 768,
+        metric: "cosine",
+        spec: { serverless: { cloud: cloudName, region: regionName } },
+      });
+    }
+
+    /** 백터 DB 인덱스 생성 */
+    const pineconeIndex = pinecone.Index(indexName);
+    const vectorRecords = await Promise.all(
+      splitDocuments.flat().map(buildVectorRecord)
+    );
+    await chunkedUpsert(pineconeIndex, vectorRecords, "", 1000);
+
+    return splitDocuments[0];
+  } catch (error) {
+    console.error("seeding Error: ", error);
+    throw error;
+  }
+};
+
+const splitPageToDocument = async (page: Page, splitter: DocumentSplitter) => {
+  return splitter.splitDocuments([
+    new Document({
+      pageContent: page.content,
+      metadata: { url: page.url },
+    }),
+  ]);
+};
+
+/** AI연결 */
+const googleAI = new GoogleGenerativeAI(
+  (process.env.GOOGLE_API_KEY || "").trim()
+);
+
+const embeddingModel = googleAI.getGenerativeModel({
+  model: "text-embedding-004",
+});
+
+const getEmbeddings = async (input: string): Promise<number[]> => {
+  const cleaned = input.replace(/\s+/g, " ").slice(0, 8000);
+  const embedRes = await embeddingModel.embedContent(cleaned);
+  return embedRes.embedding.values as number[];
+};
+
+const buildVectorRecord = async (doc: Document) => {
+  const values = await getEmbeddings(doc.pageContent);
+  return {
+    id: `${Date.now()}`,
+    values,
+    metadata: { url: doc.metadata.url },
+  } satisfies PineconeRecord;
+};
+
+const chunkedUpsert = async (
+  index: Index,
+  vectors: PineconeRecord[],
+  namespace: string,
+  batchSize = 1000
+) => {
+  for (let i = 0; i < vectors.length; i += batchSize) {
+    const batch = vectors.slice(i, i + batchSize);
+    if (namespace) {
+      await index.namespace(namespace).upsert(batch);
+    } else {
+      await index.upsert(batch);
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "localstorage-slim": "^2.7.1",
     "next": "latest",
     "next-auth": "5.0.0-beta.25",
+    "node-html-markdown": "^1.3.0",
     "postcss": "8.5.1",
     "postgres": "^3.4.6",
     "react": "latest",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "autoprefixer": "10.4.20",
     "bcrypt": "^5.1.1",
+    "cheerio": "^1.1.2",
     "clsx": "^2.1.1",
     "localstorage-slim": "^2.7.1",
     "next": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.25
         version: 5.0.0-beta.25(next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      node-html-markdown:
+        specifier: ^1.3.0
+        version: 1.3.0
       postcss:
         specifier: 8.5.1
         version: 8.5.1
@@ -1577,6 +1580,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
@@ -1941,6 +1948,13 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-html-markdown@1.3.0:
+    resolution: {integrity: sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==}
+    engines: {node: '>=10.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -4176,6 +4190,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   htmlparser2@10.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -4513,6 +4529,15 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-html-markdown@1.3.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
 
   node-releases@2.0.19: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
+      cheerio:
+        specifier: ^1.1.2
+        version: 1.1.2
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -952,6 +955,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -1005,6 +1011,13 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.1.2:
+    resolution: {integrity: sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1070,6 +1083,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1149,6 +1169,19 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -1175,6 +1208,17 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -1533,6 +1577,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -1541,6 +1588,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1911,6 +1962,9 @@ packages:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
     deprecated: This package is no longer supported.
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   nypm@0.6.1:
     resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
     engines: {node: ^14.16.0 || >=16.10.0}
@@ -1983,6 +2037,15 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2211,6 +2274,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -2454,6 +2520,10 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici@7.15.0:
+    resolution: {integrity: sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==}
+    engines: {node: '>=20.18.1'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2477,6 +2547,14 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3273,6 +3351,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -3340,6 +3420,29 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.1.2:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.0.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.15.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -3403,6 +3506,16 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
 
   cssesc@3.0.0: {}
 
@@ -3468,6 +3581,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
@@ -3490,6 +3621,15 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -4036,6 +4176,13 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  htmlparser2@10.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -4044,6 +4191,10 @@ snapshots:
       - supports-color
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -4380,6 +4531,10 @@ snapshots:
       gauge: 3.0.2
       set-blocking: 2.0.0
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   nypm@0.6.1:
     dependencies:
       citty: 0.1.6
@@ -4468,6 +4623,19 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -4683,6 +4851,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.26.0: {}
 
@@ -5027,6 +5197,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici@7.15.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.3
@@ -5068,6 +5240,12 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
## 구현 화면
<img width="1996" height="1378" alt="스크린샷 2025-09-08 시간: 02 28 51" src="https://github.com/user-attachments/assets/df097acc-4f2f-4e40-a9c2-4acb4f024c9d" />

## 주요 기능
- crawler를 통해 전달받은 url 크롤링
- GoogleGenerativeAI (text-embedding-004)로 임베딩 벡터 생성
- Pinecone 인덱스에 벡터 업서트 (chunkedUpsert)

## 상세 설명

- 시딩 구현: 특정 봇(botId)의 회사 URL을 크롤링한 결과를 가지고, 텍스트를 임베딩하여 Pinecone 인덱스에 저장합니다.
- 봇아이디  저장:  botId를 함께 저장하여, 추후 RAG 단계에서 botId 기반으로 인덱스 검색이 가능하도록 설계했습니다.

## 참고사항

- 아키텍처: 챗봇별로 URL 크롤링 → 문서 임베딩 → Pinecone에 저장 → 이후 RAG 검색 단계에서 botId 메타데이터로 필터링 가능
- .env에 아래 키 추가 필요

```
PINECONE_API_KEY= ...
GOOGLE_API_KEY= ...
```
[PINECONE_API_KEY 발급](https://app.pinecone.io/organizations/-OZYJTBk-1ziCgOGoy1v/projects/7a7e958a-3534-4bf7-8891-9b8701fc6c8f/keys)
[GOOGLE_API_KEY 발급](https://aistudio.google.com/app/apikey)

## 실행방법
포스트맨 에서 POST 요청으로 URL 넣기 `http://localhost:3000/api/crawl `

포스트맨 BODY 값에 아래 값 넣어주기
```
{
  "botId": "bot_12345",
  "url": "http://localhost:3000",
  "limit": 2,
  "indexName": "local-seed-test-768",
  "options": {
    "splittingMethod": "recursive",
    "chunkSize": 500,
    "chunkOverlap": 50
  },
  "cloudName": "aws",
  "regionName": "us-east-1"
}
```
임시 http://localhost:3000/api/crawl/route.ts 파일 설정 후 실행

## PR 체크 사항

- [ ] 전달받은 url에서 페이지가 정상적으로 크롤링되고, 텍스트가 문서(pageContent) 형태로 변환되는가?
- [ ] chunkedUpsert 로직을 통해 생성된 벡터들이 Pinecone 인덱스에 문제없이 업서트되는가?
- [ ] { botId, document } 구조로 응답이 반환되는가?


## 리뷰 반영사항

-