### PR TITLE
Design: login UI 구현 및 auth 인증 연결

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -82,7 +82,6 @@ const LoginPage = () => {
                 </Link>
               </div>
               <div className="flex items-center justify-between">
-                <label className="flex items-center gap-2 text-sm"></label>
                 <Link
                   href="/signup"
                   className="text-sm underline underline-offset-4 hover:opacity-80"

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -14,8 +14,11 @@ import { Input } from "@/components/ui/input";
 import { signIn } from "@/auth.server";
 import { AuthError } from "next-auth";
 import { redirect } from "next/navigation";
+import { useFormStatus } from "react-dom";
 
 const LoginPage = () => {
+  const { pending } = useFormStatus();
+
   return (
     <div className="min-h-screen w-full bg-gradient-to-br from-background via-muted/50 to-muted/30 flex items-center justify-center p-6">
       <Card className="w-full max-w-md shadow-lg">
@@ -90,8 +93,8 @@ const LoginPage = () => {
                 </Link>
               </div>
 
-              <Button type="submit" className="w-full">
-                로그인
+              <Button type="submit" className="w-full" disabled={pending}>
+                {pending ? "로그인 중..." : "로그인"}
               </Button>
             </div>
           </form>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import Link from "next/link";
 import { Mail, Lock } from "lucide-react";
@@ -11,8 +13,30 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { signIn } from "next-auth/react";
 
 const LoginPage = () => {
+  const [error, setError] = React.useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    const form = new FormData(e.currentTarget);
+    const email = String(form.get("email") || "");
+    const password = String(form.get("password") || "");
+
+    const res = await signIn("credentials", {
+      email,
+      password,
+      redirect: true,
+      callbackUrl: "http://localhost:3000",
+    });
+
+    if (res?.error) {
+      setError("이메일 또는 비밀번호를 다시 확인해주세요.");
+    }
+  };
   return (
     <div className="min-h-screen w-full bg-gradient-to-br from-background via-muted/50 to-muted/30 flex items-center justify-center p-6">
       <Card className="w-full max-w-md shadow-lg">
@@ -24,7 +48,7 @@ const LoginPage = () => {
         </CardHeader>
 
         <CardContent>
-          <form className="grid gap-4">
+          <form className="grid gap-4" onSubmit={onSubmit}>
             <div className="grid gap-2">
               <div className="relative">
                 <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+import Link from "next/link";
+import { Mail, Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+const LoginPage = () => {
+  return (
+    <div className="min-h-screen w-full bg-gradient-to-br from-background via-muted/50 to-muted/30 flex items-center justify-center p-6">
+      <Card className="w-full max-w-md shadow-lg">
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-2xl">로그인</CardTitle>
+          <CardDescription>
+            계정에 로그인하고 대시보드를 계속하세요.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          <form className="grid gap-4">
+            <div className="grid gap-2">
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  className="pl-9"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
+                <Input
+                  id="password"
+                  name="password"
+                  type="password"
+                  placeholder="••••••••"
+                  className="pl-9"
+                  required
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <Link
+                href="/forgot-password"
+                className="text-xs underline underline-offset-4 hover:opacity-80"
+              >
+                비밀번호를 잊으셨나요?
+              </Link>
+            </div>
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm"></label>
+              <Link
+                href="/signup"
+                className="text-sm underline underline-offset-4 hover:opacity-80"
+              >
+                회원가입
+              </Link>
+            </div>
+
+            <Button type="submit" className="w-full">
+              로그인
+            </Button>
+          </form>
+        </CardContent>
+
+        <CardFooter className="flex flex-col items-start gap-2 text-xs text-muted-foreground">
+          <p>
+            로그인함으로써{" "}
+            <Link href="/terms" className="underline underline-offset-4">
+              서비스 약관
+            </Link>
+            과{" "}
+            <Link href="/privacy" className="underline underline-offset-4">
+              개인정보 처리방침
+            </Link>
+            에 동의합니다.
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import Link from "next/link";
 import { Mail, Lock } from "lucide-react";
@@ -13,30 +11,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { signIn } from "next-auth/react";
+import { signIn } from "@/auth.server";
+import { AuthError } from "next-auth";
+import { redirect } from "next/navigation";
 
 const LoginPage = () => {
-  const [error, setError] = React.useState<string | null>(null);
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setError(null);
-
-    const form = new FormData(e.currentTarget);
-    const email = String(form.get("email") || "");
-    const password = String(form.get("password") || "");
-
-    const res = await signIn("credentials", {
-      email,
-      password,
-      redirect: true,
-      callbackUrl: "http://localhost:3000",
-    });
-
-    if (res?.error) {
-      setError("이메일 또는 비밀번호를 다시 확인해주세요.");
-    }
-  };
   return (
     <div className="min-h-screen w-full bg-gradient-to-br from-background via-muted/50 to-muted/30 flex items-center justify-center p-6">
       <Card className="w-full max-w-md shadow-lg">
@@ -48,55 +27,74 @@ const LoginPage = () => {
         </CardHeader>
 
         <CardContent>
-          <form className="grid gap-4" onSubmit={onSubmit}>
-            <div className="grid gap-2">
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  className="pl-9"
-                  required
-                />
+          <form
+            action={async (formData) => {
+              "use server";
+              try {
+                const email = formData.get("email") as string;
+                const password = formData.get("password") as string;
+                await signIn("credentials", {
+                  email,
+                  password,
+                  redirectTo: "/dashboard",
+                });
+              } catch (error) {
+                if (error instanceof AuthError) {
+                  return redirect("/login");
+                }
+                throw error;
+              }
+            }}
+          >
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
+                  <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    className="pl-9"
+                    required
+                  />
+                </div>
               </div>
-            </div>
-
-            <div className="grid gap-2">
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
-                <Input
-                  id="password"
-                  name="password"
-                  type="password"
-                  placeholder="••••••••"
-                  className="pl-9"
-                  required
-                />
+              <div className="grid gap-2">
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
+                  <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    placeholder="••••••••"
+                    className="pl-9"
+                    required
+                  />
+                </div>
               </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <Link
-                href="/forgot-password"
-                className="text-xs underline underline-offset-4 hover:opacity-80"
-              >
-                비밀번호를 잊으셨나요?
-              </Link>
-            </div>
-            <div className="flex items-center justify-between">
-              <label className="flex items-center gap-2 text-sm"></label>
-              <Link
-                href="/signup"
-                className="text-sm underline underline-offset-4 hover:opacity-80"
-              >
-                회원가입
-              </Link>
-            </div>
+              <div className="flex items-center justify-between">
+                <Link
+                  href="/forgot-password"
+                  className="text-xs underline underline-offset-4 hover:opacity-80"
+                >
+                  비밀번호를 잊으셨나요?
+                </Link>
+              </div>
+              <div className="flex items-center justify-between">
+                <label className="flex items-center gap-2 text-sm"></label>
+                <Link
+                  href="/signup"
+                  className="text-sm underline underline-offset-4 hover:opacity-80"
+                >
+                  회원가입
+                </Link>
+              </div>
 
-            <Button type="submit" className="w-full">
-              로그인
-            </Button>
+              <Button type="submit" className="w-full">
+                로그인
+              </Button>
+            </div>
           </form>
         </CardContent>
 

--- a/app/dashboard/[userId]/page.tsx
+++ b/app/dashboard/[userId]/page.tsx
@@ -1,5 +1,22 @@
-const DashBoardPage = () => {
-  return <p>page</p>;
+import { auth } from "@/auth.server";
+import { notFound } from "next/navigation";
+
+const DashBoardPage = async ({
+  params,
+}: {
+  params: Promise<{ userId: string }>;
+}) => {
+  const { userId } = await params;
+  const session = await auth();
+  if (!session?.user) notFound();
+
+  if ((session.user as any).id !== userId) notFound();
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold">대시보드</h1>
+    </main>
+  );
 };
 
 export default DashBoardPage;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@/auth.server";
+import { redirect } from "next/navigation";
+
+const DashboardHub = () => {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const userId =
+    (session.user as any)?.id || (session as any).userId || (session as any).id;
+
+  if (!userId) redirect("/login");
+  redirect(`/dashboard/${userId}`);
+};
+
+export default DashboardHub;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@/auth.server";
 import { redirect } from "next/navigation";
 
-const DashboardHub = () => {
+const DashboardHub = async () => {
   const session = await auth();
   if (!session) redirect("/login");
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ const LandingPage = () => {
             <span>로그인 하기</span>
           </Link>
           <Link
-            href="/demo"
+            href="/login"
             className="text-aline gap-5 self-start rounded-lg bg-brown-700 px-7 py-3.5 text-base md:px-8 md:py-4 md:text-lg lg:px-10 lg:py-5 lg:text-xl font-medium text-white transition-colors hover:bg-brown-200 hover:text-black"
           >
             <span>무료로 체험하기</span>


### PR DESCRIPTION
## 구현 화면
<img width="783" height="599" alt="스크린샷 2025-09-10 오전 9 07 10" src="https://github.com/user-attachments/assets/d196e5cd-c32e-4948-ae6a-238e2c374d5e" />

## 구현 설명
- Design: login UI 구현 및 auth 인증 연결하였습니다.
- 로그인 페이지(UI) → 대시보드 허브`/dashboard `→ 사용자별 대시보드`/dashboard/[userId]`로 자연스럽게 이동되며, 세션 검증을 통해 비로그인·타 사용자 접근을 차단합니다.

## 상세 설명
- 로그인 페이지 UI 구현 ((auth)/login/page.tsx)
  - `shadcn/ui `컴포넌트로 로그인 폼 구성 하였습니다.
  - 서버 액션에서 `signIn("credentials") `호출 및 성공 시 `/dashboard`로 리다이렉트합니다.
  - `AuthError`를 캐치하여 실패 시 /login으로 복귀합니다.

- 대시보드 허브 라우트 추가 (/dashboard/page.tsx)
  - `auth()`로 세션을 확인하고, 세션 내 user.id(또는 호환 키)를 읽어 `/dashboard/[userId]`로 즉시 리다이렉트 합니다.
  - 사용자별 동적 라우트 구조를 사용하는 프로젝트에서, 고정 진입점(`/dashboard`)을 통일하기 위한 허브 역할을 구현했습니다.

- 사용자별 대시보드 페이지 (/dashboard/[userId]/page.tsx)
  - `auth()`로 세션 확인을 합니다. 
  - URL의` [userId]`와 `session.user.id`가 일치하지 않으면` notFound()` 처리(접근 제어)합니다.

## 참고사항
- dev 로 머지하여 파일을 병합할때 리다이렉트 경로를 변경  `/dashboard/[userId]/invoices/sessions` 로 변경 예정입니다.


## PR 체크 사항

- [ ] 로그인 페이지(`(auth)/login/page.tsx`)에서 이메일/비밀번호를 올바르게 입력하면` /dashboard`로 리다이렉트 되는지 확인하였습니다.
- [ ] 잘못된 이메일/비밀번호를 입력하면 로그인 실패 후 `/login`으로 복귀하는지 확인하였습니다.
- [ ] UI 요소 (이메일/비밀번호 인풋, “로그인” 버튼, “비밀번호 찾기/회원가입” 링크 등) 가 의도대로 표시되고 동작하는지 확인하였습니다.
- [ ] 로그인 성공 후 `/dashboard `허브가 올바른 `userId`를 추출하여 `/dashboard/[userId]`로 즉시 리다이렉트 되는지 확인


## 리뷰 반영사항

-