### PR TITLE
Design: description header bar 컴포넌트 구현 및 챗봇 설정 페이지 조정

### DIFF
--- a/app/dashboard/[userId]/chatbot/setting/page.tsx
+++ b/app/dashboard/[userId]/chatbot/setting/page.tsx
@@ -157,12 +157,10 @@ const ChatbotSetting = ({
   }
 
   return (
-    <div className="flex-1 space-y-4">
-      <h2 className="text-3xl font-bold tracking-tight">AI 챗봇 설정</h2>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
+    <div className="flex-1 space-y-4 mx-4 my-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start min-h-0">
         {/* 왼쪽: 설정 카드 */}
-        <div className="lg:col-span-2 space-y-8  max-h-[calc(100vh-12rem)] overflow-y-auto pr-6">
+        <div className="lg:col-span-2 space-y-8 pr-6">
           <Card>
             <CardHeader>
               <CardTitle>데스커 기본 설정</CardTitle>
@@ -269,7 +267,7 @@ const ChatbotSetting = ({
         </div>
 
         {/* 오른쪽: 모의 채팅방 */}
-        <div className="lg:col-span-1">
+        <div className="lg:col-span-1 sticky top-4 self-start mr-4">
           <Card className="h-[700px] flex flex-col">
             <CardHeader className="flex-row items-center justify-between space-y-0">
               <div>

--- a/app/ui/dashboard/description-header-bar.tsx
+++ b/app/ui/dashboard/description-header-bar.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+type DescriptionBarProps = {
+  icon: any;
+  text: string;
+};
+
+const DescriptionBar = ({ icon: Icon, text }: DescriptionBarProps) => {
+  return (
+    <div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-5">
+      <Icon className="h-5 w-5 text-foreground" />
+      <p className="text-base font-medium">{text}</p>
+    </div>
+  );
+};
+
+export default DescriptionBar;

--- a/app/ui/dashboard/description-header-bar.tsx
+++ b/app/ui/dashboard/description-header-bar.tsx
@@ -3,13 +3,25 @@ import * as React from "react";
 type DescriptionBarProps = {
   icon: any;
   text: string;
+  headerBarDetailText: string;
 };
 
-const DescriptionBar = ({ icon: Icon, text }: DescriptionBarProps) => {
+const DescriptionBar = ({
+  icon: Icon,
+  text,
+  headerBarDetailText,
+}: DescriptionBarProps) => {
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background px-4 py-5">
-      <Icon className="h-5 w-5 text-foreground" />
-      <p className="text-base font-medium">{text}</p>
+    <div className="sticky top-0 z-10 border-b bg-background px-4 py-5">
+      <div className="flex flex-col items-start gap-1">
+        <div className="flex items-center gap-2">
+          <Icon className="h-5 w-5 text-foreground" />
+          <p className="text-base font-medium">{text}</p>
+        </div>
+        <p className="text-sm text-muted-foreground ml-0">
+          {headerBarDetailText}
+        </p>
+      </div>
     </div>
   );
 };

--- a/app/ui/dashboard/description-header-bar.tsx
+++ b/app/ui/dashboard/description-header-bar.tsx
@@ -2,25 +2,27 @@ import * as React from "react";
 
 type DescriptionBarProps = {
   icon: any;
-  text: string;
-  headerBarDetailText: string;
+  title?: string;
+  headerBarDetailText?: string;
 };
 
 const DescriptionBar = ({
   icon: Icon,
-  text,
+  title,
   headerBarDetailText,
 }: DescriptionBarProps) => {
   return (
-    <div className="sticky top-0 z-10 border-b bg-background px-4 py-5">
-      <div className="flex flex-col items-start gap-1">
-        <div className="flex items-center gap-2">
-          <Icon className="h-5 w-5 text-foreground" />
-          <p className="text-base font-medium">{text}</p>
+    <div className="sticky top-0 z-10 bg-background border-b border-foreground/10">
+      <div className="px-4 py-5">
+        <div className="flex flex-col items-start gap-1">
+          <div className="flex items-center gap-2">
+            <Icon className="h-5 w-5 text-foreground" />
+            <p className="text-base font-medium">{title}</p>
+          </div>
+          <p className="text-sm text-muted-foreground ml-0">
+            {headerBarDetailText}
+          </p>
         </div>
-        <p className="text-sm text-muted-foreground ml-0">
-          {headerBarDetailText}
-        </p>
       </div>
     </div>
   );

--- a/app/ui/dashboard/side-bar-shell.tsx
+++ b/app/ui/dashboard/side-bar-shell.tsx
@@ -19,7 +19,12 @@ import {
 } from "@/components/ui/tooltip";
 
 import { MessageCircleMore, ContactRound, Bot, UserCog } from "lucide-react";
-import { SIDE_BAR_TOOLTIP_MESSAGE } from "@/config/constants";
+import {
+  SIDE_BAR_TOOLTIP_MESSAGE,
+  HEADER_BAR_DEATAIL_MESSAGE,
+} from "@/config/constants";
+
+import DescriptionBar from "./description-header-bar";
 
 type SidebarShellProps = {
   userId: string;
@@ -35,29 +40,35 @@ const SideBarShell = ({ userId, children }: SidebarShellProps) => {
       url: `/dashboard/${userId}/invoices/sessions`,
       icon: MessageCircleMore,
       text: SIDE_BAR_TOOLTIP_MESSAGE.SESSIONS_LIST,
+      headerBarText: HEADER_BAR_DEATAIL_MESSAGE.SESSIONS_LIST,
     },
     {
       title: "ContactRound",
       url: `/dashboard/${userId}/invoices/inquiries`,
       icon: ContactRound,
       text: SIDE_BAR_TOOLTIP_MESSAGE.VISITOR_CONTACT,
+      headerBarText: HEADER_BAR_DEATAIL_MESSAGE.VISITOR_CONTACT,
     },
     {
       title: "Bot",
       url: `/dashboard/${userId}/chatbot/setting`,
       icon: Bot,
       text: SIDE_BAR_TOOLTIP_MESSAGE.AI_SETTING,
+      headerBarText: HEADER_BAR_DEATAIL_MESSAGE.AI_SETTING,
     },
     {
       title: "UserCog",
       url: `/dashboard/${userId}/user/setting`,
       icon: UserCog,
       text: SIDE_BAR_TOOLTIP_MESSAGE.PERSONAL_SETTINGS,
+      headerBarText: HEADER_BAR_DEATAIL_MESSAGE.PERSONAL_SETTINGS,
     },
   ];
 
+  const activeItem = items.find((it) => pathname.includes(it.url));
+
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen w-full">
       <Sidebar className="border-r border-foreground">
         <SidebarContent>
           <SidebarGroup>
@@ -102,7 +113,16 @@ const SideBarShell = ({ userId, children }: SidebarShellProps) => {
         </SidebarContent>
       </Sidebar>
 
-      <main className="flex-1 overflow-y-auto">{children}</main>
+      <div className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden">
+        <DescriptionBar
+          icon={activeItem?.icon}
+          title={activeItem?.text}
+          headerBarDetailText={activeItem?.headerBarText}
+        />
+        <main className="flex-1 min-h-0 overflow-y-auto bg-background">
+          {children}
+        </main>
+      </div>
     </div>
   );
 };

--- a/config/constants.js
+++ b/config/constants.js
@@ -50,3 +50,14 @@ export const SIDE_BAR_TOOLTIP_MESSAGE = {
   AI_SETTING: "AI 설정",
   PERSONAL_SETTINGS: "개인 설정",
 };
+
+export const HEADER_BAR_DEATAIL_MESSAGE = {
+  SESSIONS_LIST:
+    "방문자와 나눈 모든 대화 세션을 확인할 수 있습니다. 필요한 세션을 선택해 상세 메시지를 열람하세요.",
+  VISITOR_CONTACT:
+    "방문자가 남긴 문의와 연락처 정보를 관리할 수 있습니다. 빠른 대응을 위해 연락처 정보를 확인하세요.",
+  AI_SETTING:
+    "AI 챗봇의 관련 설정을 할 수 있습니다. URL을 등록해 챗봇이 최신 정보를 학습하도록 설정해 보세요.",
+  PERSONAL_SETTINGS:
+    "계정과 사용자 정보를 관리할 수 있습니다. 개인 설정을 조정하세요.",
+};


### PR DESCRIPTION
## 구현 화면
<img width="1532" height="967" alt="스크린샷 2025-10-31 오후 5 40 25" src="https://github.com/user-attachments/assets/165b1b9f-2810-4e13-a95a-0acc444eb526" />


## 상세 설명

- DescriptionBar 컴포넌트 추가 (app/ui/dashboard/description-header-bar.tsx) 
  - icon, text, headerBarDetailText를 props로 받아 렌더링합니다.
  - 레이아웃: 아이콘 + 제목, 상세 설명 으로 구성되어 있습니다.
  - usePathname()으로 현재 경로를 읽고 라우트에 따른 헤더바 내부 내용이 자동 전환이 됩니다.
  
 - 챗봇 설정 페이지 UI 개선
   - DescriptionBar(헤더바) 의 제목과 챗봇 설정 페이지의 제목이 중복되어 챗봇 설정 페이지의 제목을 삭제했습니다.
   - 챗봇 설정 페이지에서 하단의 여백이 남아있어 여백을 삭제하였습니다.
   - 페이지 외곽 여백(mx-4 my-6) 및 오른쪽 채팅 UI 여백(mr-4)을 추가하여 시각적 정렬 개선 하였습니다. 


## PR 체크 사항

- [ ] 각 경로 진입 시 헤더바가 해당 경로의 아이콘/제목/상세 문구로 올바르게 표시되는가?
- [ ] 스크롤 시 헤더바가 상단에 고정(sticky) 되고 본문은 정상 스크롤되는가?


## 리뷰 반영사항
-